### PR TITLE
Do not write file if contents have not changed

### DIFF
--- a/src/main/java/com/tchristofferson/configupdater/ConfigUpdater.java
+++ b/src/main/java/com/tchristofferson/configupdater/ConfigUpdater.java
@@ -8,6 +8,8 @@ import org.bukkit.plugin.Plugin;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -25,11 +27,19 @@ public class ConfigUpdater {
         FileConfiguration currentConfig = YamlConfiguration.loadConfiguration(toUpdate);
         Map<String, String> comments = parseComments(plugin, resourceName, defaultConfig);
         Map<String, String> ignoredSectionsValues = parseIgnoredSections(toUpdate, currentConfig, comments, ignoredSections == null ? Collections.emptyList() : ignoredSections);
-        write(defaultConfig, currentConfig, toUpdate, comments, ignoredSectionsValues);
+
+        // will write updated config file "contents" to a string
+        StringWriter writer = new StringWriter();
+        write(defaultConfig, currentConfig, new BufferedWriter(writer), comments, ignoredSectionsValues);
+        String value = writer.toString(); // config contents
+
+        Path toUpdatePath = toUpdate.toPath();
+        if (!value.equals(Files.readString(toUpdatePath))) { // if updated contents are not the same as current file contents, update
+            Files.writeString(toUpdatePath, value);
+        }
     }
 
-    private static void write(FileConfiguration defaultConfig, FileConfiguration currentConfig, File toUpdate, Map<String, String> comments, Map<String, String> ignoredSectionsValues) throws IOException {
-        BufferedWriter writer = new BufferedWriter(new FileWriter(toUpdate));
+    private static void write(FileConfiguration defaultConfig, FileConfiguration currentConfig, BufferedWriter writer, Map<String, String> comments, Map<String, String> ignoredSectionsValues) throws IOException {
         //Used for converting objects to yaml, then cleared
         FileConfiguration parserConfig = new YamlConfiguration();
 


### PR DESCRIPTION
Currently, any call of `ConfigUpdater#update` will write the new file with the computed contents. However, writting the file to the disk is NOT necessary if the "new" and "current" contents are the same. This commit changes this, by writting "updated contents" to a string first and then to the file if it detects any change.