### PR TITLE
Fix more UTF8 issues

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 8
+    - name: Set up JDK 21
       uses: actions/setup-java@v3
       with:
-        java-version: '8'
+        java-version: '21'
         distribution: 'temurin'
         cache: maven
         

--- a/pom.xml
+++ b/pom.xml
@@ -79,8 +79,8 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
+            <version>5.14.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/com/tchristofferson/configupdater/ConfigUpdaterTest.java
+++ b/src/test/java/com/tchristofferson/configupdater/ConfigUpdaterTest.java
@@ -11,9 +11,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.stubbing.Answer;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -24,10 +22,11 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+//JUnit tests should be run with -Dfile.encoding=GBK to make sure UTF8 is used everywhere
 public class ConfigUpdaterTest {
 
     private static final String FILE_NAME = "config.yml";
@@ -69,7 +68,7 @@ public class ConfigUpdaterTest {
     public void testUpdateMethodToMakeSureIgnoredSectionsAreHandledCorrectly() throws IOException, InvalidConfigurationException {
         File toUpdate = new File(FILE_NAME);
 
-        FileConfiguration config = YamlConfiguration.loadConfiguration(toUpdate);
+        FileConfiguration config = YamlConfiguration.loadConfiguration(new BufferedReader(new InputStreamReader(Files.newInputStream(toUpdate.toPath()), StandardCharsets.UTF_8)));
         config.set("a-section-with-ignored-sections.sub-ignored.ignored.value3", 3);
         config.set("a-section-with-ignored-sections.sub-ignored.ignored2.value", 1);
 
@@ -141,8 +140,10 @@ public class ConfigUpdaterTest {
     }
 
     private void saveDefaultConfig(File toUpdate) throws IOException, URISyntaxException {
-        FileConfiguration configuration = YamlConfiguration.loadConfiguration(Files.newBufferedReader(getResourcePath(), StandardCharsets.UTF_8));
-        configuration.save(toUpdate);
+        byte[] bytes = Files.readAllBytes(getResourcePath());
+        BufferedWriter writer = Files.newBufferedWriter(toUpdate.toPath(), StandardCharsets.UTF_8);
+        writer.write(new String(bytes, StandardCharsets.UTF_8));
+        writer.close();
     }
 
     private Path getResourcePath() throws URISyntaxException {


### PR DESCRIPTION
Spigot 1.8 doesn't use utf8 if default encoding is GBK, as an example.